### PR TITLE
Use `ci4rail-base-image` as basis image of `ci4rail-devtools-image`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Ci4Rail GmbH
+   Copyright 2022 Ci4Rail GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# meta-ci4rail-bsp
+
+This layer provides recipes used for HW platform tests and bringup of Ci4Rail Hardware.
+
+## Dependencies
+
+This layer depends on:
+
+* URI: git://github.com/ci4rail/meta-ci4rail-bsp
+  * branch: dunfell
+
+## Build
+
+See [build instructions](https://github.com/ci4rail/yocto-images/tree/cleanup#building) from Ci4Rail repository for build definitons and scripts for yocto builds.
+
+## Maintainers
+
+* Ci4Rail GmbH `engineering@ci4rail.com`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# meta-ci4rail-bsp
+# meta-ci4rail-devtools
 
 This layer provides recipes used for HW platform tests and bringup of Ci4Rail Hardware.
 
@@ -11,7 +11,7 @@ This layer depends on:
 
 ## Build
 
-See [build instructions](https://github.com/ci4rail/yocto-images/tree/cleanup#building) from Ci4Rail repository for build definitons and scripts for yocto builds.
+See [build instructions](https://github.com/ci4rail/yocto-images#building) from Ci4Rail repository for build definitons and scripts for yocto builds.
 
 ## Maintainers
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,3 +11,4 @@ BBFILE_PRIORITY_meta-ci4rail-devtools = "101"
 
 LAYERDEPENDS_meta-ci4rail-devtools = "core "
 LAYERSERIES_COMPAT_meta-ci4rail-devtools = "dunfell"
+LAYERDEPENDS_meta-ci4rail-devtools = "meta-ci4rail-bsp"

--- a/recipes-images/images/ci4rail-devtools-image.bb
+++ b/recipes-images/images/ci4rail-devtools-image.bb
@@ -1,96 +1,38 @@
+require ../../../meta-ci4rail-bsp/recipes-images/images/ci4rail-base-image.bb
+
 SUMMARY = "Ci4Rail Embedded Linux Image Devtools Image"
 DESCRIPTION = "Image including develpoment tools for HW bringup and tests"
 
 LICENSE = "MIT"
 
-inherit core-image
-
 #Prefix to the resulting deployable tarball name
 export IMAGE_BASENAME = "Devtools-Image"
-MACHINE_NAME ?= "${MACHINE}"
-GIT_VERSION := "${@d.getVar('BB_ORIGENV',False).getVar('IMAGE_GIT_VERSION', False) or 'NoVersion'}"
-NAME_SUFFIX := "${@d.getVar('BB_ORIGENV',False).getVar('IMAGE_NAME_SUFFIX', False) or ''}"
-IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}_${GIT_VERSION}${NAME_SUFFIX}"
 
-# Copy Licenses to image /usr/share/common-license
-COPY_LIC_MANIFEST ?= "1"
-COPY_LIC_DIRS ?= "1"
+# Remove ROOTFS_RO_UNNEEDED = "update-rc.d base-passwd"
+ROOTFS_RO_UNNEEDED = ""
 
-add_rootfs_version () {
-    printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) \\\n \\\l\n" > ${IMAGE_ROOTFS}/etc/issue
-    printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) %%h\n" > ${IMAGE_ROOTFS}/etc/issue.net
-    printf "${IMAGE_NAME}\n\n" >> ${IMAGE_ROOTFS}/etc/issue
-    printf "${IMAGE_NAME}\n\n" >> ${IMAGE_ROOTFS}/etc/issue.net
-}
-# add the rootfs version to the welcome banner
-ROOTFS_POSTPROCESS_COMMAND += "add_rootfs_version;"
+# Allow no root password
+IMAGE_FEATURES += "debug-tweaks"
 
-IMAGE_LINGUAS = "en-us"
-
-# Entropy source daemon
-RANDOM_HELPER = "rng-tools"
-
-USB_GADGET = " \
-    libusbgx \
-    libusbgx-examples \
-"
-
-IMAGE_INSTALL +=  " packagegroup-boot \
-                    packagegroup-basic \
-                    packagegroup-base-tdx-cli \
-                    packagegroup-benchmark-tdx-cli \
-                    packagegroup-devel-tdx-cli \
-                    packagegroup-machine-tdx-cli \
-                    packagegroup-networking-tdx-cli \
-                    packagegroup-wifi-tdx-cli \
-                    packagegroup-wifi-fw-tdx-cli \
-                    udev-extraconf \
-                    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \
-                    bzip2 \
-                    e2fsprogs \
-                    e2fsprogs-resize2fs \
-                    e2fsprogs-tune2fs \
-                    ethtool \
-                    gpsd \
-                    grep \
-                    lsof \
-                    minicom \
-                    mmc-utils-cos \
-                    pciutils \
-                    phytool \
-                    procps \
-                    ${RANDOM_HELPER} \
-                    stress-ng \
-                    sqlite3 \
-                    tdx-oak-sensors \
-                    ${USB_GADGET} \
-                    util-linux \
-                    cpuburn-a53 \
-                    clpeak \
-                    memtester \
-                    pcimem \
-                    dhrystone \
-                    stressapptest \
-                    tinymembench \
-                    whetstone \
-                    fio \
-                    lshw \
-                    hwdata \
-                    pciutils \
-                    minicom \
-                    nano \
-                    networkmanager \
-                    modemmanager \
-                    dhcp-server \
-                    chrony \
-                    chronyc \
-                    gpsdtestclient \
-                    disktest \
-                    eth-test-raw \
-                    netio-monitor \
-                    dfu-util \
-                    io4edge-cli \
-                    ttynvt \
-                    serial-test \
-                    python3-pyserial \
-                "
+# Add development tooling
+IMAGE_INSTALL += "\
+                  phytool \
+                  stress-ng \
+                  tdx-oak-sensors \
+                  cpuburn-a53 \
+                  clpeak \
+                  memtester \
+                  pcimem \
+                  dhrystone \
+                  stressapptest \
+                  tinymembench \
+                  whetstone \
+                  fio \
+                  lshw \
+                  hwdata \
+                  gpsdtestclient \
+                  disktest \
+                  eth-test-raw \
+                  netio-monitor \
+                  serial-test \
+                  "


### PR DESCRIPTION
- Update license
- Derive `ci4rail-devtools-image` from `ci4rail-base-image`
- Move configs from local conf to image, if possible
- Add readme and layer dependencies